### PR TITLE
Refactor liquidity pool logic and improve slashing checks

### DIFF
--- a/src/constants/Contract.ts
+++ b/src/constants/Contract.ts
@@ -23,7 +23,6 @@ export const MAX_ACTIVATION_DELAY: u8 = 3;
 export const MAXIMUM_NUMBER_OF_PROVIDER_TO_RESETS_BEFORE_QUEUING: u8 = 100;
 export const MAXIMUM_NUMBER_OF_PROVIDER_TO_RESETS: u32 = 40;
 
-export const MIN_SATOSHI_RESERVE: u256 = u256.fromU64(100_000); // 0.001 BTC
 export const MAX_PRICE_IMPACT_BPS = u256.fromU64(10_000); // 40% 3_000 15_000
 export const MAX_CUMULATIVE_IMPACT_BPS = u256.fromU32(20_000);
 
@@ -46,12 +45,6 @@ export const CSV_BLOCKS_REQUIRED: i32 = 1;
 export const MAXIMUM_PROVIDER_PER_RESERVATIONS: u8 = 140;
 
 export const AT_LEAST_PROVIDERS_TO_PURGE: u32 = 100;
-
-// 4 block grace period
-export const SLASH_GRACE_WINDOW: u64 = 4;
-
-// number of blocks in 14 days
-export const SLASH_RAMP_UP_BLOCKS: u64 = 2_016;
 
 export const ENABLE_INDEX_VERIFICATION: boolean = false;
 

--- a/src/managers/LiquidityQueue.ts
+++ b/src/managers/LiquidityQueue.ts
@@ -186,7 +186,7 @@ export class LiquidityQueue implements ILiquidityQueue {
         this.liquidityQueueReserve.virtualTokenReserve = value;
     }
 
-    public accruePenalty(penalty: u128, half: u128): void {
+    /*public accruePenalty(penalty: u128, half: u128): void {
         if (!penalty.isZero()) {
             this.ensurePenaltyNotLessThanHalf(penalty, half);
 
@@ -221,7 +221,7 @@ export class LiquidityQueue implements ILiquidityQueue {
 
             addAmountToStakingContract(penaltyU256);
         }
-    }
+    }*/
 
     public addReservation(reservation: Reservation): void {
         this.reservationManager.addReservation(reservation.getCreationBlock(), reservation);
@@ -342,7 +342,6 @@ export class LiquidityQueue implements ILiquidityQueue {
     }
 
     public distributeFee(totalFee: u256): void {
-        this.decreaseVirtualTokenReserve(totalFee);
         this.decreaseTotalReserve(totalFee);
         addAmountToStakingContract(totalFee);
     }
@@ -525,10 +524,6 @@ export class LiquidityQueue implements ILiquidityQueue {
 
     public updateVirtualPoolIfNeeded(): void {
         const currentBlock: u64 = Blockchain.block.number;
-        // disabled for live recalc of virtual reserves
-        /*if (currentBlock <= this.lastVirtualUpdateBlock) {
-            return;
-        }*/
 
         let B: u256 = u256.fromU64(this.virtualSatoshisReserve);
         let T: u256 = this.virtualTokenReserve;
@@ -539,7 +534,9 @@ export class LiquidityQueue implements ILiquidityQueue {
         const dT_add: u256 = this.totalTokensSellActivated;
         if (!dT_add.isZero()) {
             T = SafeMath.add(T, dT_add);
-            B = SafeMath.div(initialK, T);
+
+            // Ceiling division to preserve k: ceil(k / T) = (k + T - 1) / T
+            B = SafeMath.div(SafeMath.sub(SafeMath.add(initialK, T), u256.One), T);
 
             // Verify K is maintained
             const newK = SafeMath.mul(B, T);
@@ -559,9 +556,6 @@ export class LiquidityQueue implements ILiquidityQueue {
         const dB_buy: u256 = u256.fromU64(this.totalSatoshisExchangedForTokens);
 
         if (!dT_buy.isZero() || !dB_buy.isZero()) {
-            //T = T > dT_buy ? SafeMath.sub(T, dT_buy) : u256.One;
-            //B = SafeMath.add(B, dB_buy);
-
             if (dT_buy >= T) {
                 throw new Revert(
                     `Impossible state: Cannot buy ${dT_buy} tokens, only ${T} available`,
@@ -574,8 +568,8 @@ export class LiquidityQueue implements ILiquidityQueue {
             // Remove tokens bought
             T = SafeMath.sub(T, dT_buy);
 
-            // Calculate B to maintain constant product
-            B = SafeMath.div(k, T);
+            // Ceiling division to preserve k: ceil(k / T) = (k + T - 1) / T
+            B = SafeMath.div(SafeMath.sub(SafeMath.add(k, T), u256.One), T);
         }
 
         if (T.isZero()) {
@@ -599,23 +593,6 @@ export class LiquidityQueue implements ILiquidityQueue {
 
         this.lastVirtualUpdateBlock = currentBlock;
     }
-
-    /*private calculateQueueImpact(): u256 {
-        const queuedTokens = this.liquidity;
-
-        if (queuedTokens.isZero()) {
-            return u256.Zero;
-        }
-
-        // Calculate ratio = 1 + Q/T
-        const ratio = SafeMath.add(u256.One, SafeMath.div(queuedTokens, this.virtualTokenReserve));
-
-        // Use precise logarithm calculation
-        const lnValue = preciseLog(ratio);
-
-        // Impact = T * ln(1 + Q/T) / 1e6 (since log is scaled)
-        return SafeMath.div(SafeMath.mul(this.virtualTokenReserve, lnValue), u256.fromU64(1000000));
-    }*/
 
     protected computeVolatility(
         currentBlock: u64,
@@ -657,20 +634,6 @@ export class LiquidityQueue implements ILiquidityQueue {
             SafeMath.mul(this.virtualTokenReserve, lnSquared),
             u256.fromU64(1000000),
         );
-
-        /*const queuedTokens = this.liquidity;
-        if (queuedTokens.isZero()) {
-            return u256.Zero;
-        }
-
-        // Impact = Q * T / (Q + T)
-        // This is the harmonic mean of Q and T
-        const numerator = SafeMath.mul(queuedTokens, this.virtualTokenReserve);
-        const denominator = SafeMath.add(queuedTokens, this.virtualTokenReserve);
-
-        return SafeMath.div(numerator, denominator);*/
-
-        //return SafeMath.sqrt(SafeMath.mul(queuedTokens, this.virtualTokenReserve));
     }
 
     private computeInitialSatoshisReserve(initialLiquidity: u256, floorPrice: u256): u64 {

--- a/src/managers/TradeManager.ts
+++ b/src/managers/TradeManager.ts
@@ -188,13 +188,19 @@ export class TradeManager implements ITradeManager {
         const halfCred: u128 = u128.add(halfFloor, u128.and(totalLiquidity, u128.One));
 
         // EDGE CASE: Handle providers who bypassed normal listing
-        if (!currentQuote.isZero() && provider.getVirtualBTCContribution() === 0) {
+        if (
+            !currentQuote.isZero() &&
+            provider.getVirtualBTCContribution() === 0 &&
+            !provider.isInitialLiquidityProvider()
+        ) {
+            throw new Revert("Impossible state: provider's virtual BTC contribution is zero.");
+
             // They bypassed listing, so record their FULL value now
-            const btcContribution = tokensToSatoshis(totalLiquidity.toU256(), currentQuote);
+            /*const btcContribution = tokensToSatoshis(totalLiquidity.toU256(), currentQuote);
             provider.setVirtualBTCContribution(btcContribution);
 
             // Since they bypassed listing, we need to apply BOTH halves now
-            this.liquidityQueueReserve.addToTotalTokensSellActivated(totalLiquidity.toU256());
+            this.liquidityQueueReserve.addToTotalTokensSellActivated(totalLiquidity.toU256());*/
         } else {
             // Normal case: Apply the SECOND 50% of tokens to the virtual reserves
             // (First 50% was already applied during listing)

--- a/src/managers/interfaces/ILiquidityQueue.ts
+++ b/src/managers/interfaces/ILiquidityQueue.ts
@@ -24,7 +24,7 @@ export interface ILiquidityQueue {
 
     cleanUpQueues(currentQuote: u256): void;
 
-    accruePenalty(penalty: u128, half: u128): void;
+    //accruePenalty(penalty: u128, half: u128): void;
 
     addReservation(reservation: Reservation): void;
 

--- a/src/models/Provider.ts
+++ b/src/models/Provider.ts
@@ -310,7 +310,7 @@ export class Provider {
      * @returns {boolean} - true if reserved amount is valid; false if not.
      */
     public canCoverReservedAmount(): boolean {
-        return u128.lt(this.getLiquidityAmount(), this.getReservedAmount()) ? false : true;
+        return !u128.lt(this.getLiquidityAmount(), this.getReservedAmount());
     }
 
     /**

--- a/src/operations/ListTokensForSaleOperation.ts
+++ b/src/operations/ListTokensForSaleOperation.ts
@@ -380,15 +380,13 @@ export class ListTokensForSaleOperation extends BaseOperation {
         this.pullInTokens();
         this.assertQueueSwitchAllowed();
         this.addProviderToQueue();
-        this.updateProviderLiquidity();
+        this.updateProviderLiquidity(); // Sets to oldLiquidity + amountIn (GROSS)
         this.assignBlockNumber();
         this.assignReceiver();
 
-        // Calculate tax (if any) and get net amount
-        const taxAmount = this.deductTaxIfPriority();
+        const taxAmount = this.deductTaxIfPriority(); // Subtracts tax from provider
         const netAmount = SafeMath.sub(this.amountIn256, taxAmount);
 
-        // Only add net amount to reserves
         this.liquidityQueue.increaseTotalReserve(netAmount);
         if (!this.isForInitialLiquidity) {
             this.activateSlashing(netAmount);

--- a/src/operations/ListTokensForSaleOperation.ts
+++ b/src/operations/ListTokensForSaleOperation.ts
@@ -19,13 +19,10 @@ import {
     INDEX_NOT_SET_VALUE,
     MAX_CUMULATIVE_IMPACT_BPS,
     MAX_PRICE_IMPACT_BPS,
-    MAX_TOTAL_SATOSHIS,
     MAXIMUM_NUMBER_OF_PROVIDER_TO_RESETS,
-    MIN_SATOSHI_RESERVE,
     MINIMUM_LIQUIDITY_VALUE_ADD_LIQUIDITY_IN_SAT,
     PERCENT_TOKENS_FOR_PRIORITY_FACTOR_TAX,
     PERCENT_TOKENS_FOR_PRIORITY_QUEUE_TAX,
-    QUOTE_SCALE,
     TEN_THOUSAND_U256,
 } from '../constants/Contract';
 
@@ -72,143 +69,65 @@ export class ListTokensForSaleOperation extends BaseOperation {
         this.liquidityQueue.resetFulfilledProviders(MAXIMUM_NUMBER_OF_PROVIDER_TO_RESETS);
     }
 
-    protected activateSlashing(): void {
-        const newTotal: u128 = SafeMath.add128(this.oldLiquidity, this.amountIn);
+    protected activateSlashing(netAmountIn: u256): void {
+        const netAmountIn128 = netAmountIn.toU128();
+        const newTotal: u128 = SafeMath.add128(this.oldLiquidity, netAmountIn128);
         const oldHalfCred: u128 = this.half(this.oldLiquidity);
         const newHalfCred: u128 = this.half(newTotal);
         const deltaHalf: u128 = SafeMath.sub128(newHalfCred, oldHalfCred);
 
-        if (!deltaHalf.isZero()) {
-            const currentB = u256.fromU64(this.liquidityQueue.virtualSatoshisReserve);
-            const currentT = this.liquidityQueue.virtualTokenReserve;
-            const k = SafeMath.mul(currentB, currentT);
+        if (deltaHalf.isZero()) {
+            return;
+        }
 
-            // Get current price before adding
-            const priceBefore = this.liquidityQueue.quote();
-            // Simulate adding deltaHalf to token reserves via constant product
-            const newT = SafeMath.add(currentT, deltaHalf.toU256());
+        const currentT = this.liquidityQueue.virtualTokenReserve;
+        const currentB = u256.fromU64(this.liquidityQueue.virtualSatoshisReserve);
 
-            //!!!! div by 0 when newT > k or newT =0
-            const newB = SafeMath.div(k, newT);
+        if (currentT.isZero() || currentB.isZero()) {
+            throw new Revert(`NATIVE_SWAP: Pool not initialized.`);
+        }
 
-            // Calculate new price after adding
-            // Queue impact stays the same since liquidity doesn't change
-            const queuedTokens = this.liquidityQueue.liquidity;
-            const queueImpact = this.calculateNewQueueImpact(queuedTokens, newT);
-            const effectiveNewT = SafeMath.add(newT, queueImpact);
+        const deltaHalf256 = deltaHalf.toU256();
 
-            //!!!! div by 0 when newB > effectiveNewT or newB =0
-            const priceAfter = SafeMath.div(SafeMath.mul(effectiveNewT, QUOTE_SCALE), newB);
+        const maxAllowedAddition = SafeMath.div(
+            SafeMath.mul(currentT, MAX_PRICE_IMPACT_BPS),
+            TEN_THOUSAND_U256,
+        );
 
-            // Price increases when adding tokens (tokens become cheaper)
-            if (priceAfter > priceBefore) {
-                const priceImpact = SafeMath.div(
-                    SafeMath.mul(SafeMath.sub(priceAfter, priceBefore), TEN_THOUSAND_U256),
-                    priceBefore,
-                );
-
-                if (priceImpact > MAX_PRICE_IMPACT_BPS) {
-                    throw new Revert(
-                        `NATIVE_SWAP: Listing this amount of token would devalue tokens by ${priceImpact} bps. ` +
-                            `Maximum allowed is ${MAX_PRICE_IMPACT_BPS} bps. ` +
-                            `Reduce amount or wait for better market conditions.`,
-                    );
-                }
-            }
-
-            // Check minimum satoshi reserve
-            if (newB < MIN_SATOSHI_RESERVE) {
-                throw new Revert(
-                    `NATIVE_SWAP: Listing this amount of token would push satoshi reserves too low ` +
-                        `(would be ${newB}, minimum ${MIN_SATOSHI_RESERVE}). ` +
-                        `Price is too low for more liquidity.`,
-                );
-            }
-
-            // Check if pending operations would compound the issue
-            const pendingSells = this.liquidityQueue.totalTokensSellActivated;
-            const pendingBuys = this.liquidityQueue.totalTokensExchangedForSatoshis;
-
-            // Apply ALL pending sells (current deltaHalf + existing pending)
-            const totalPendingSells = SafeMath.add(deltaHalf.toU256(), pendingSells);
-            const futureT = SafeMath.add(currentT, totalPendingSells);
-
-            //!!!! div by 0 when futureT > k or futureT =0
-            const futureB = SafeMath.div(k, futureT);
-
-            // Calculate future price with queue impact
-            const futureQueueImpact = this.calculateNewQueueImpact(queuedTokens, futureT);
-            const effectiveFutureT = SafeMath.add(futureT, futureQueueImpact);
-
-            //!!!! div by 0
-            const totalPriceAfter = SafeMath.div(
-                SafeMath.mul(effectiveFutureT, QUOTE_SCALE),
-                futureB,
+        if (deltaHalf256 > maxAllowedAddition) {
+            throw new Revert(
+                `NATIVE_SWAP: Listing too large relative to pool. ` +
+                    `Adding ${deltaHalf256} tokens but max allowed is ${maxAllowedAddition} ` +
+                    `(${MAX_PRICE_IMPACT_BPS} bps of ${currentT} virtual reserve).`,
             );
-
-            if (totalPriceAfter > priceBefore) {
-                const totalPriceImpact = SafeMath.div(
-                    SafeMath.mul(SafeMath.sub(totalPriceAfter, priceBefore), TEN_THOUSAND_U256),
-                    priceBefore,
-                );
-
-                if (totalPriceImpact > MAX_CUMULATIVE_IMPACT_BPS) {
-                    throw new Revert(
-                        `NATIVE_SWAP: Cumulative token devaluation too high (${totalPriceImpact} bps). ` +
-                            `Wait for pending queue to clear.`,
-                    );
-                }
-            }
-
-            // Check future buy overflow
-            if (!pendingBuys.isZero()) {
-                // First check if buys would drain the pool
-                if (pendingBuys >= futureT) {
-                    throw new Revert(`NATIVE_SWAP: Pool would be drained by pending operations.`);
-                }
-
-                const futureK = SafeMath.mul(futureB, futureT);
-                const newFutureT = SafeMath.sub(futureT, pendingBuys);
-                //!!!! div by 0
-                const newFutureB = SafeMath.div(futureK, newFutureT);
-
-                if (newFutureB > MAX_TOTAL_SATOSHIS) {
-                    throw new Revert(
-                        `NATIVE_SWAP: Listing this amount of token would cause pool overflow after pending buys.`,
-                    );
-                }
-            }
-
-            // Track BTC contribution
-            let currentQuote = this.liquidityQueue.quote();
-            if (!currentQuote.isZero()) {
-                const newTokensBtcValue = tokensToSatoshis(this.amountIn256, currentQuote);
-                const existingContribution = this.provider.getVirtualBTCContribution();
-                const updatedContribution = existingContribution + newTokensBtcValue;
-                this.provider.setVirtualBTCContribution(updatedContribution);
-            }
-
-            // Safe to add tokens to pending operations
-            this.liquidityQueue.increaseTotalTokensSellActivated(deltaHalf.toU256());
-
-            // Clean up reservations and restore providers
-            this.liquidityQueue.updateVirtualPoolIfNeeded();
-            //this.liquidityQueue.reCalcQuote();
-            currentQuote = this.liquidityQueue.quote();
-            this.liquidityQueue.purgeReservationsAndRestoreProviders(currentQuote);
-        }
-    }
-
-    private calculateNewQueueImpact(queuedTokens: u256, newTokenReserve: u256): u256 {
-        if (queuedTokens.isZero()) {
-            return u256.Zero;
         }
 
-        // Using the same harmonic mean formula from LiquidityQueue.calculateQueueImpact()
-        const numerator = SafeMath.mul(queuedTokens, newTokenReserve);
-        const denominator = SafeMath.add(queuedTokens, newTokenReserve);
+        const pendingSells = this.liquidityQueue.totalTokensSellActivated;
+        const totalPending = SafeMath.add(deltaHalf256, pendingSells);
 
-        return SafeMath.div(numerator, denominator);
+        const maxCumulativeAddition = SafeMath.div(
+            SafeMath.mul(currentT, MAX_CUMULATIVE_IMPACT_BPS),
+            TEN_THOUSAND_U256,
+        );
+
+        if (totalPending > maxCumulativeAddition) {
+            throw new Revert(
+                `NATIVE_SWAP: Cumulative pending sells too high. ` +
+                    `Total pending would be ${totalPending}, max allowed is ${maxCumulativeAddition}.`,
+            );
+        }
+
+        // Track BTC contribution based on net amount too
+        const currentQuote = this.liquidityQueue.quote();
+        if (!currentQuote.isZero()) {
+            const newTokensBtcValue = tokensToSatoshis(netAmountIn, currentQuote);
+            const existingContribution = this.provider.getVirtualBTCContribution();
+            this.provider.setVirtualBTCContribution(existingContribution + newTokensBtcValue);
+        }
+
+        this.liquidityQueue.increaseTotalTokensSellActivated(deltaHalf256);
+        this.liquidityQueue.updateVirtualPoolIfNeeded();
+        this.liquidityQueue.purgeReservationsAndRestoreProviders(this.liquidityQueue.quote());
     }
 
     private ensureValidReceiverAddress(receiver: string): void {
@@ -472,7 +391,7 @@ export class ListTokensForSaleOperation extends BaseOperation {
         // Only add net amount to reserves
         this.liquidityQueue.increaseTotalReserve(netAmount);
         if (!this.isForInitialLiquidity) {
-            this.activateSlashing();
+            this.activateSlashing(netAmount);
         }
         this.snapshotBlockQuote();
     }

--- a/src/operations/ReserveLiquidityOperation.ts
+++ b/src/operations/ReserveLiquidityOperation.ts
@@ -182,57 +182,6 @@ export class ReserveLiquidityOperation extends BaseOperation {
         this.remainingTokens = limitedByCap;
     }
 
-    /*private limitByFuturePoolState(requestedTokens: u256): u256 {
-        // Get current state
-        let B = u256.fromU64(this.liquidityQueue.virtualSatoshisReserve);
-        let T = this.liquidityQueue.virtualTokenReserve;
-
-        // Apply pending sells first
-        const pendingSells = this.liquidityQueue.totalTokensSellActivated;
-        if (!pendingSells.isZero()) {
-            const k = SafeMath.mul(B, T);
-            T = SafeMath.add(T, pendingSells);
-            B = SafeMath.div(k, T);
-        }
-
-        // Apply pending buys
-        const pendingBuys = this.liquidityQueue.totalTokensExchangedForSatoshis;
-        if (!pendingBuys.isZero()) {
-            const k = SafeMath.mul(B, T);
-            if (pendingBuys >= T) {
-                // Already broken, no new reservations
-                return u256.Zero;
-            }
-            T = SafeMath.sub(T, pendingBuys);
-            B = SafeMath.div(k, T);
-        }
-
-        // Now check if THIS reservation would break things
-        const totalNewBuys = SafeMath.add(requestedTokens, pendingBuys);
-        if (totalNewBuys >= T) {
-            return u256.Zero; // Would consume entire pool
-        }
-
-        const k = SafeMath.mul(B, T);
-        const finalT = SafeMath.sub(T, totalNewBuys);
-        const finalB = SafeMath.div(k, finalT);
-
-        if (finalB > MAX_TOTAL_SATOSHIS) {
-            // Calculate max that can be bought
-            const minT = SafeMath.div(k, MAX_TOTAL_SATOSHIS);
-            if (minT >= T) {
-                return u256.Zero; // Already at limit
-            }
-            const maxTotal = SafeMath.sub(T, minT);
-            if (pendingBuys >= maxTotal) {
-                return u256.Zero; // Pending buys already max out capacity
-            }
-            return SafeMath.sub(maxTotal, pendingBuys);
-        }
-
-        return requestedTokens;
-    }*/
-
     private computeTokensToReserve(availableLiquidity: u128): u128 {
         let targetTokensToReserve: u128;
 

--- a/src/operations/ReserveLiquidityOperation.ts
+++ b/src/operations/ReserveLiquidityOperation.ts
@@ -25,6 +25,7 @@ import {
 } from '../constants/Contract';
 import { Provider } from '../models/Provider';
 import { ReservationProviderData } from '../models/ReservationProdiverData';
+import { min128 } from '../utils/MathUtils';
 
 export class ReserveLiquidityOperation extends BaseOperation {
     protected currentQuote: u256 = u256.Zero;
@@ -88,19 +89,13 @@ export class ReserveLiquidityOperation extends BaseOperation {
             availableLiquidity,
         );
 
-        // It is possible to lose 1 token due to round down.
-        const finalTokensToReserve: CappedTokensResult = satoshisToTokens128(
-            satoshis,
-            this.currentQuote,
-        );
+        const tokenResult: CappedTokensResult = satoshisToTokens128(satoshis, this.currentQuote);
 
-        if (!finalTokensToReserve.tokens.isZero()) {
-            this.applyReservation(
-                reservation,
-                provider,
-                finalTokensToReserve.tokens,
-                finalTokensToReserve.satoshis,
-            );
+        // Cap by tokensToAttempt to prevent rounding from inflating the reservation
+        const finalTokensToReserve: u128 = min128(tokenResult.tokens, tokensToAttempt);
+
+        if (!finalTokensToReserve.isZero()) {
+            this.applyReservation(reservation, provider, finalTokensToReserve, satoshis);
 
             this.handleProviderPurgeQueues(provider);
 

--- a/src/operations/SwapOperation.ts
+++ b/src/operations/SwapOperation.ts
@@ -48,7 +48,8 @@ export class SwapOperation extends BaseOperation {
 
             this.updateLiquidityQueue(
                 trade.totalTokensReserved,
-                totalTokensPurchased,
+                initialTotalTokensPurchased, // Pre-fee amount for virtual pool
+                totalTokensPurchased, // Post-fee amount for actual reserve
                 totalSatoshisSpent,
             );
 
@@ -156,11 +157,12 @@ export class SwapOperation extends BaseOperation {
 
     private updateLiquidityQueue(
         totalTokensReserved: u256,
-        totalTokensPurchased: u256,
+        totalTokensForPool: u256, // Pre-fee, for virtual pool tracking
+        totalTokensForReserve: u256, // Post-fee, for actual reserve
         totalSatoshisSpent: u64,
     ): void {
         this.liquidityQueue.decreaseTotalReserved(totalTokensReserved);
-        this.liquidityQueue.decreaseTotalReserve(totalTokensPurchased);
-        this.liquidityQueue.recordTradeVolumes(totalTokensPurchased, totalSatoshisSpent);
+        this.liquidityQueue.decreaseTotalReserve(totalTokensForReserve);
+        this.liquidityQueue.recordTradeVolumes(totalTokensForPool, totalSatoshisSpent);
     }
 }

--- a/src/utils/SatoshisConversion.ts
+++ b/src/utils/SatoshisConversion.ts
@@ -13,8 +13,11 @@ export function tokensToSatoshis(tokenAmount: u256, scaledPrice: u256): u64 {
         return 0;
     }
 
+    const numerator = SafeMath.mul(tokenAmount, QUOTE_SCALE);
+
+    // Ceiling division: (numerator + scaledPrice - 1) / scaledPrice
     const satoshis = SafeMath.div(
-        SafeMath.mul(SafeMath.add(tokenAmount, u256.One), QUOTE_SCALE), // We have to do plus one here due to the round down
+        SafeMath.sub(SafeMath.add(numerator, scaledPrice), u256.One),
         scaledPrice,
     );
 

--- a/src/utils/SatoshisConversion.ts
+++ b/src/utils/SatoshisConversion.ts
@@ -14,18 +14,17 @@ export function tokensToSatoshis(tokenAmount: u256, scaledPrice: u256): u64 {
     }
 
     const numerator = SafeMath.mul(tokenAmount, QUOTE_SCALE);
+    const satoshis = SafeMath.div(numerator, scaledPrice);
 
-    // Ceiling division: (numerator + scaledPrice - 1) / scaledPrice
-    const satoshis = SafeMath.div(
-        SafeMath.sub(SafeMath.add(numerator, scaledPrice), u256.One),
-        scaledPrice,
-    );
+    // Check if there's a remainder - if so, round up
+    const remainder = SafeMath.mod(numerator, scaledPrice);
+    const finalSatoshis = remainder.isZero() ? satoshis : SafeMath.add(satoshis, u256.One);
 
-    if (satoshis > MAX_TOTAL_SATOSHIS) {
+    if (finalSatoshis > MAX_TOTAL_SATOSHIS) {
         throw new Revert(`Impossible state: The total number of satoshis is out of range.`);
     }
 
-    return satoshis.toU64();
+    return finalSatoshis.toU64();
 }
 
 export function tokensToSatoshis128(tokenAmount: u128, scaledPrice: u256): u64 {


### PR DESCRIPTION
Removed unused penalty accrual and slashing constants, refactored slashing activation to use net amounts and simplified price impact checks, improved ceiling division for virtual reserve calculations, and clarified token-to-satoshis conversion. Also updated SwapOperation to distinguish between pre-fee and post-fee token amounts for pool and reserve tracking.

1. Fee Distribution Virtual Pool Fix

Problem: Fee distribution was removing tokens from both actual reserves and virtual token reserve, causing the virtual pool's constant product (k) to shrink with every fee-generating trade. Over time this compounds and corrupts price discovery.

Fix: Fee distribution now only affects actual reserves, leaving the virtual pool price oracle untouched.


2. Pre-Fee Amount for Virtual Pool Tracking

Problem: The virtual pool was receiving post-fee token amounts during swap tracking, meaning it saw smaller trades than actually occurred, corrupting price discovery.

Fix: Virtual pool now receives pre-fee trade amounts for accurate price tracking, while actual reserve accounting uses post-fee amounts.


3. Priority Queue Tax Virtual Pool Alignment

Problem: Virtual pool impact during listing was calculated using gross token amount before priority queue tax, but actual reserves only received net amount after tax. This caused divergence between virtual pool state and actual token availability.

Fix: Virtual pool impact is now calculated using net amount after tax, matching actual reserves.


4. Initial Liquidity Provider Double-Count Prevention

Problem: An edge case in provider activation would add tokens to the sell accumulator for the initial liquidity provider, even though their tokens were already in virtual reserves from pool creation. This caused double-counting.

Fix: Added explicit check to exclude initial liquidity provider from the edge case handling.

5. Ceiling Division for k Preservation

Problem: Integer division when recalculating virtual BTC reserve rounded down, causing k to slightly decrease with every pool update. Over millions of operations this compounds and drains the virtual pool.

Fix: Changed to ceiling division so k either stays constant or slightly increases, never decreases.


6. Proper Ceiling Division in Token-to-Satoshi Conversion

Problem: The previous rounding adjustment was a hack that wasn't mathematically correct ceiling division.

Fix: Implemented proper ceiling division that only rounds up when there's an actual remainder, ensuring  users always pay enough satoshis without overpaying on exact divisions.


7. Swap Logic Trusts Reserved Amount

Problem: During swap execution, the system recalculated tokens from satoshis sent, which due to rounding could differ from the reserved amount. This caused reserved amount to exceed liquidity over multiple operations.

Fix: If user sends sufficient satoshis to cover their reservation, they receive exactly what they reserved. Recalculation only occurs if they underpaid.


8. Reservation Rounding Cap

Problem: Round-trip conversion during reservation (tokens to satoshis with ceiling, back to tokens with floor) could result in slightly more tokens than originally intended, potentially reserving more than available liquidity.

Fix: Final reserved token amount is capped by the originally intended amount after the round-trip conversion.