### PR TITLE
Add stable pool support OP-20S (Stable extension)

### DIFF
--- a/src/constants/Contract.ts
+++ b/src/constants/Contract.ts
@@ -47,6 +47,9 @@ export const DEFAULT_STABLE_AMPLIFICATION: u64 = 100;
 export const POOL_TYPE_STANDARD: u8 = 0;
 export const POOL_TYPE_STABLE: u8 = 1;
 
+// Peg rate scale: pegRate is satoshis per token * 1e8
+export const PEG_RATE_SCALE: u256 = u256.fromU64(100_000_000); // 1e8
+
 /**
  * WARNING. This is very important because the limit of input UTXOs possible per transaction is 250. We give ourselves an error margin of 10. !!!!??? 10???
  */

--- a/src/constants/Contract.ts
+++ b/src/constants/Contract.ts
@@ -8,7 +8,7 @@ export const INITIAL_FEE_COLLECT_ADDRESS: string =
 
 export const ENABLE_FEES: bool = true;
 export const QUOTE_SCALE: u256 = u256.fromU64(100_000_000);
-export const RESERVATION_EXPIRE_AFTER_IN_BLOCKS: u64 = 5;
+export const RESERVATION_EXPIRE_AFTER_IN_BLOCKS: u64 = 8;
 export const VOLATILITY_WINDOW_IN_BLOCKS: u32 = 8;
 export const STRICT_MINIMUM_PROVIDER_RESERVATION_AMOUNT_IN_SAT: u64 = 600;
 export const MINIMUM_PROVIDER_RESERVATION_AMOUNT_IN_SAT: u64 = 1000;
@@ -38,6 +38,14 @@ export const BLOCK_NOT_SET_VALUE: u64 = U64.MAX_VALUE;
 export const EMIT_PURGE_EVENTS: boolean = false;
 export const EMIT_PROVIDERCONSUMED_EVENTS: boolean = false;
 export const CSV_BLOCKS_REQUIRED: i32 = 1;
+
+// Default amplification coefficient for stable pools
+// Higher A = tighter liquidity around peg, lower slippage for small trades
+// Typical values: 100-1000 for stablecoin pairs
+export const DEFAULT_STABLE_AMPLIFICATION: u64 = 100;
+
+export const POOL_TYPE_STANDARD: u8 = 0;
+export const POOL_TYPE_STABLE: u8 = 1;
 
 /**
  * WARNING. This is very important because the limit of input UTXOs possible per transaction is 250. We give ourselves an error margin of 10. !!!!??? 10???

--- a/src/constants/Contract.ts
+++ b/src/constants/Contract.ts
@@ -50,6 +50,21 @@ export const POOL_TYPE_STABLE: u8 = 1;
 // Peg rate scale: pegRate is satoshis per token * 1e8
 export const PEG_RATE_SCALE: u256 = u256.fromU64(100_000_000); // 1e8
 
+// Peg rate bounds for defensive validation
+// Min: 1 sat per token (1e8 scaled) - tokens worth less than 1 sat are unrealistic
+export const MIN_PEG_RATE: u256 = u256.fromU64(100_000_000);
+
+// Max: 1M BTC per token (1e14 sats * 1e8 scale) - catches overflow from malicious tokens
+export const MAX_PEG_RATE: u256 = u256.fromUint8ArrayBE(
+    Uint8Array.wrap(
+        changetype<ArrayBuffer>([
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x1e, 0x19,
+            0xe0, 0xc9, 0xba, 0xb2,
+        ] as StaticArray<u8>),
+    ),
+);
+
 /**
  * WARNING. This is very important because the limit of input UTXOs possible per transaction is 250. We give ourselves an error margin of 10. !!!!??? 10???
  */

--- a/src/constants/StoredPointers.ts
+++ b/src/constants/StoredPointers.ts
@@ -46,3 +46,5 @@ export const FEES_ADDRESS_POINTER: u16 = Blockchain.nextPointer;
 export const WITHDRAW_MODE_POINTER: u16 = Blockchain.nextPointer;
 export const NORMAL_QUEUE_FULFILLED: u16 = Blockchain.nextPointer;
 export const PRIORITY_QUEUE_FULFILLED: u16 = Blockchain.nextPointer;
+
+export const POOL_TYPES_POINTER: u16 = Blockchain.nextPointer;

--- a/src/extern/OP20StableQuery.ts
+++ b/src/extern/OP20StableQuery.ts
@@ -1,0 +1,103 @@
+import { Address, Blockchain, BytesWriter, encodeSelector, Revert, Selector, } from '@btc-vision/btc-runtime/runtime';
+import { u256 } from '@btc-vision/as-bignum/assembly';
+
+/**
+ * OP-20S: Stable Token Extension Standard
+ *
+ * Stablecoins must implement this interface to be used with NativeSwap stable pools.
+ *
+ * Required methods:
+ *   pegRate(): u256      - Target price in satoshis per token, scaled by 1e8
+ *   pegAuthority(): Address - Address authorized to update peg rate
+ *   pegUpdatedAt(): u64  - Block number of last peg update
+ *
+ * The stablecoin issuer is responsible for:
+ * 1. Keeping pegRate() updated via their own oracle/multisig
+ * 2. Maintaining actual peg through collateral/mint/burn mechanisms
+ *
+ * NativeSwap only reads from this interface, never writes.
+ *
+ * Example pegRate values (assuming BTC = $100,000):
+ *   1 USD = $1 = 1000 sats -> pegRate = 1000 * 1e8 = 100_000_000_000
+ *   1 EUR  = $1.10 = 1100 sats -> pegRate = 1100 * 1e8 = 110_000_000_000
+ */
+
+const PEG_RATE_SELECTOR: Selector = encodeSelector('pegRate()');
+const PEG_AUTHORITY_SELECTOR: Selector = encodeSelector('pegAuthority()');
+const PEG_UPDATED_AT_SELECTOR: Selector = encodeSelector('pegUpdatedAt()');
+
+export class OP20StableQuery {
+    /**
+     * Get the peg rate from a stable token.
+     * Reverts if the token doesn't implement pegRate() or returns zero.
+     *
+     * @param token - The stable token address
+     * @returns The peg rate scaled by 1e8
+     */
+    public static getPegRate(token: Address): u256 {
+        const calldata = new BytesWriter(4);
+        calldata.writeSelector(PEG_RATE_SELECTOR);
+
+        const pegRate = Blockchain.call(token, calldata).data.readU256();
+
+        if (pegRate.isZero()) {
+            throw new Revert('OP20S: Token returned zero peg rate');
+        }
+
+        return pegRate;
+    }
+
+    /**
+     * Get the peg authority address.
+     * Reverts if the token doesn't implement pegAuthority().
+     */
+    public static getPegAuthority(token: Address): Address {
+        const calldata = new BytesWriter(4);
+        calldata.writeSelector(PEG_AUTHORITY_SELECTOR);
+
+        const response = Blockchain.call(token, calldata);
+        return response.data.readAddress();
+    }
+
+    /**
+     * Get the block number when peg was last updated.
+     * Reverts if the token doesn't implement pegUpdatedAt().
+     */
+    public static getPegUpdatedAt(token: Address): u64 {
+        const calldata = new BytesWriter(4);
+        calldata.writeSelector(PEG_UPDATED_AT_SELECTOR);
+
+        const response = Blockchain.call(token, calldata);
+        return response.data.readU64();
+    }
+
+    /**
+     * Validate that peg data is not stale.
+     *
+     * @param token - The stable token address
+     * @param maxStalenessBlocks - Maximum blocks since last update (0 = no check)
+     * @param currentBlock - Current block number
+     */
+    public static validatePegFreshness(
+        token: Address,
+        maxStalenessBlocks: u64,
+        currentBlock: u64,
+    ): void {
+        if (maxStalenessBlocks === 0) {
+            return;
+        }
+
+        const updatedAt = OP20StableQuery.getPegUpdatedAt(token);
+
+        if (updatedAt === 0) {
+            throw new Revert('OP20S: Peg has never been updated');
+        }
+
+        const staleness = currentBlock - updatedAt;
+        if (staleness > maxStalenessBlocks) {
+            throw new Revert(
+                `OP20S: Peg data stale. Last update: ${updatedAt}, current: ${currentBlock}, max staleness: ${maxStalenessBlocks}`,
+            );
+        }
+    }
+}

--- a/src/managers/LiquidityQueue.ts
+++ b/src/managers/LiquidityQueue.ts
@@ -1,7 +1,6 @@
 import {
     Address,
     Blockchain,
-    Potential,
     Revert,
     SafeMath,
     StoredU256,
@@ -11,14 +10,18 @@ import { u128, u256 } from '@btc-vision/as-bignum/assembly';
 
 import {
     ANTI_BOT_MAX_TOKENS_PER_RESERVATION,
+    POOL_TYPES_POINTER,
     RESERVATION_SETTINGS_POINTER,
 } from '../constants/StoredPointers';
 
 import { addAmountToStakingContract, Provider } from '../models/Provider';
 import { Reservation } from '../models/Reservation';
 import {
+    DEFAULT_STABLE_AMPLIFICATION,
     ENABLE_FEES,
     MAX_TOTAL_SATOSHIS,
+    POOL_TYPE_STABLE,
+    POOL_TYPE_STANDARD,
     QUOTE_SCALE,
     TEN_THOUSAND_U256,
     VOLATILITY_WINDOW_IN_BLOCKS,
@@ -31,6 +34,13 @@ import { ILiquidityQueue } from './interfaces/ILiquidityQueue';
 import { IDynamicFee } from './interfaces/IDynamicFee';
 import { preciseLog } from '../utils/MathUtils';
 
+class StableSwapResult {
+    constructor(
+        public newT: u256,
+        public newB: u256,
+    ) {}
+}
+
 export class LiquidityQueue implements ILiquidityQueue {
     public readonly token: Address;
 
@@ -42,8 +52,9 @@ export class LiquidityQueue implements ILiquidityQueue {
 
     private readonly settings: StoredU64;
     private readonly _maxTokensPerReservation: StoredU256;
+    private readonly _poolTypes: StoredU64;
     private readonly timeoutEnabled: boolean;
-    private _calculatedQuote: Potential<u256> = null;
+    //private _calculatedQuote: Potential<u256> = null;
 
     constructor(
         token: Address,
@@ -69,6 +80,7 @@ export class LiquidityQueue implements ILiquidityQueue {
         );
 
         this.settings = new StoredU64(RESERVATION_SETTINGS_POINTER, tokenIdUint8Array);
+        this._poolTypes = new StoredU64(POOL_TYPES_POINTER, tokenIdUint8Array);
         this.timeoutEnabled = timeoutEnabled;
 
         this.updateVirtualPoolIfNeeded();
@@ -76,6 +88,27 @@ export class LiquidityQueue implements ILiquidityQueue {
         if (purgeOldReservations && this.virtualSatoshisReserve > 0) {
             this.purgeReservationsAndRestoreProviders(this.quote());
         }
+    }
+
+    public get poolType(): u8 {
+        return <u8>this._poolTypes.get(0);
+    }
+
+    public set poolType(value: u8) {
+        this._poolTypes.set(0, <u64>value);
+    }
+
+    public get amplification(): u64 {
+        const stored = this._poolTypes.get(1);
+        return stored === 0 ? DEFAULT_STABLE_AMPLIFICATION : stored;
+    }
+
+    public set amplification(value: u64) {
+        this._poolTypes.set(1, value);
+    }
+
+    public get isStablePool(): bool {
+        return this.poolType === POOL_TYPE_STABLE;
     }
 
     public get antiBotExpirationBlock(): u64 {
@@ -186,43 +219,6 @@ export class LiquidityQueue implements ILiquidityQueue {
         this.liquidityQueueReserve.virtualTokenReserve = value;
     }
 
-    /*public accruePenalty(penalty: u128, half: u128): void {
-        if (!penalty.isZero()) {
-            this.ensurePenaltyNotLessThanHalf(penalty, half);
-
-            const penaltyU256: u256 = penalty.toU256();
-            const penaltyLeft = SafeMath.sub128(penalty, half);
-            const penaltyLeftU256: u256 = penaltyLeft.toU256();
-
-            this.decreaseTotalReserve(penaltyU256);
-            if (!penaltyLeftU256.isZero()) {
-                // Get current state BEFORE modifications
-                const currentBTC = u256.fromU64(this.virtualSatoshisReserve);
-                const currentTokens = this.virtualTokenReserve;
-
-                if (!currentBTC.isZero() && !currentTokens.isZero()) {
-                    // Calculate BTC to remove BEFORE modifying tokens
-                    const btcToRemove = SafeMath.div(
-                        SafeMath.mul(penaltyLeftU256, currentBTC),
-                        currentTokens,
-                    );
-
-                    // Now remove BOTH
-                    this.decreaseVirtualTokenReserve(penaltyLeftU256);
-
-                    if (
-                        !btcToRemove.isZero() &&
-                        btcToRemove.toU64() <= this.virtualSatoshisReserve
-                    ) {
-                        this.decreaseVirtualSatoshisReserve(btcToRemove.toU64());
-                    }
-                }
-            }
-
-            addAmountToStakingContract(penaltyU256);
-        }
-    }*/
-
     public addReservation(reservation: Reservation): void {
         this.reservationManager.addReservation(reservation.getCreationBlock(), reservation);
     }
@@ -239,17 +235,11 @@ export class LiquidityQueue implements ILiquidityQueue {
         return this.reservationManager.blockWithReservationsLength();
     }
 
-    /*public recordTradeVolumes(tokensOut: u256, satoshisIn: u64): void {
-        this.increaseTotalSatoshisExchangedForTokens(satoshisIn);
-        this.increaseTotalTokensExchangedForSatoshis(tokensOut);
-    }*/
-
     public recordTradeVolumes(tokensOut: u256, satoshisIn: u64): void {
         // Get current state
         const currentVirtualT = this.virtualTokenReserve;
         const currentVirtualB = u256.fromU64(this.virtualSatoshisReserve);
 
-        // Get current accumulators
         const currentPendingSells = this.totalTokensSellActivated;
         const currentPendingBuys = this.totalTokensExchangedForSatoshis;
         const currentPendingBTC = u256.fromU64(this.totalSatoshisExchangedForTokens);
@@ -260,9 +250,19 @@ export class LiquidityQueue implements ILiquidityQueue {
         let projectedB = currentVirtualB;
 
         if (!currentPendingSells.isZero()) {
-            const k = SafeMath.mul(currentVirtualB, currentVirtualT);
-            projectedT = SafeMath.add(currentVirtualT, currentPendingSells);
-            projectedB = SafeMath.div(k, projectedT);
+            if (this.isStablePool) {
+                const result = this.applyStableSwapSell(
+                    currentVirtualT,
+                    currentVirtualB,
+                    currentPendingSells,
+                );
+                projectedT = result.newT;
+                projectedB = result.newB;
+            } else {
+                const k = SafeMath.mul(currentVirtualB, currentVirtualT);
+                projectedT = SafeMath.add(currentVirtualT, currentPendingSells);
+                projectedB = SafeMath.div(k, projectedT);
+            }
         }
 
         // Check if buys (including this new trade) would exceed projected reserves
@@ -425,6 +425,8 @@ export class LiquidityQueue implements ILiquidityQueue {
         providerId: u256,
         initialLiquidity: u128,
         maxReserves5BlockPercent: u64,
+        poolType: u8 = POOL_TYPE_STANDARD,
+        amplification: u64 = DEFAULT_STABLE_AMPLIFICATION,
     ): void {
         this.initialLiquidityProviderId = providerId;
         this.virtualTokenReserve = initialLiquidity.toU256();
@@ -433,6 +435,11 @@ export class LiquidityQueue implements ILiquidityQueue {
             floorPrice,
         );
         this.maxReserves5BlockPercent = maxReserves5BlockPercent;
+        this.poolType = poolType;
+
+        if (poolType === POOL_TYPE_STABLE) {
+            this.amplification = amplification;
+        }
     }
 
     public isReservationActiveAtIndex(blockNumber: u64, index: u32): boolean {
@@ -452,14 +459,6 @@ export class LiquidityQueue implements ILiquidityQueue {
 
     // Return number of tokens per satoshi
     public quote(): u256 {
-        /*
-        if (this._calculatedQuote) {
-            return this._calculatedQuote as u256;
-        }
-
-        this._calculatedQuote = this.calculateQuote();
-        return this._calculatedQuote as u256;
-        */
         const TOKEN: u256 = this.virtualTokenReserve;
         const BTC: u64 = this.virtualSatoshisReserve;
 
@@ -476,14 +475,14 @@ export class LiquidityQueue implements ILiquidityQueue {
 
         // Add impact to token reserves ONLY for price calculation
         const effectiveT = SafeMath.add(TOKEN, queueImpact);
-        const scaled = SafeMath.mul(effectiveT, QUOTE_SCALE);
 
+        if (this.isStablePool) {
+            return this.stableQuote(effectiveT, u256.fromU64(BTC));
+        }
+
+        const scaled = SafeMath.mul(effectiveT, QUOTE_SCALE);
         return SafeMath.div(scaled, u256.fromU64(BTC));
     }
-
-    /*public reCalcQuote(): void {
-        this._calculatedQuote = this.calculateQuote();
-    }*/
 
     public removeFromNormalQueue(provider: Provider): void {
         this.providerManager.removeFromNormalQueue(provider);
@@ -505,19 +504,205 @@ export class LiquidityQueue implements ILiquidityQueue {
         this.settings.save();
         this.providerManager.save();
         this.quoteManager.save();
+        this._poolTypes.save();
     }
 
     public setBlockQuote(): void {
-        //this.reCalcQuote();
         this.quoteManager.setBlockQuote(Blockchain.block.number, this.quote());
     }
 
     public updateVirtualPoolIfNeeded(): void {
         const currentBlock: u64 = Blockchain.block.number;
 
-        let B: u256 = u256.fromU64(this.virtualSatoshisReserve);
-        let T: u256 = this.virtualTokenReserve;
+        const B: u256 = u256.fromU64(this.virtualSatoshisReserve);
+        const T: u256 = this.virtualTokenReserve;
 
+        if (this.isStablePool) {
+            this.updateVirtualPoolStable(T, B);
+        } else {
+            this.updateVirtualPoolStandard(T, B);
+        }
+
+        this.resetAccumulators();
+
+        this.dynamicFee.volatility = this.computeVolatility(
+            currentBlock,
+            VOLATILITY_WINDOW_IN_BLOCKS,
+        );
+
+        this.lastVirtualUpdateBlock = currentBlock;
+    }
+
+    // StableSwap quote calculation
+    // Uses the derivative of the StableSwap invariant to get marginal price
+
+    protected computeVolatility(
+        currentBlock: u64,
+        windowSize: u32 = VOLATILITY_WINDOW_IN_BLOCKS,
+    ): u256 {
+        let volatility: u256 = u256.Zero;
+
+        const currentQuote: u256 = this.quoteManager.getBlockQuote(currentBlock);
+        const oldBlock: u64 = currentBlock - windowSize;
+        const oldQuote: u256 = this.quoteManager.getBlockQuote(oldBlock);
+
+        if (!oldQuote.isZero() && !currentQuote.isZero()) {
+            let diff = u256.sub(currentQuote, oldQuote);
+
+            if (diff.toI64() < 0) {
+                diff = u256.mul(diff, u256.fromI64(-1));
+            }
+
+            volatility = SafeMath.div(SafeMath.mul(diff, TEN_THOUSAND_U256), oldQuote);
+        }
+
+        return volatility;
+    }
+
+    // Compute StableSwap invariant D
+    // D satisfies: A * n^n * sum(x_i) + D = A * D * n^n + D^(n+1) / (n^n * prod(x_i))
+    // For n=2: A * 4 * (x + y) + D = A * D * 4 + D^3 / (4 * x * y)
+
+    // For small trades near equilibrium, price approaches 1:1 (adjusted by peg)
+    private stableQuote(T: u256, B: u256): u256 {
+        const A = u256.fromU64(this.amplification);
+        const TWO = u256.fromU32(2);
+        const FOUR = u256.fromU32(4);
+
+        // D = total liquidity (sum when balanced)
+        const D = this.computeStableD(T, B, A);
+
+        // StableSwap price formula:
+        // dy/dx = (A * x + D^3 / (4 * A * x^2 * y)) / (A * y + D^3 / (4 * A * x * y^2))
+        // Simplified for marginal price at current reserves
+
+        // For price in terms of tokens per satoshi:
+        // price = (A * B + D^3 / (4 * A * B * T^2)) / (A * T + D^3 / (4 * A * B^2 * T))
+
+        const D3 = SafeMath.mul(SafeMath.mul(D, D), D);
+        const fourA = SafeMath.mul(FOUR, A);
+
+        // Numerator: A * B + D^3 / (4 * A * B * T^2)
+        const T2 = SafeMath.mul(T, T);
+        const denomPart1 = SafeMath.mul(SafeMath.mul(fourA, B), T2);
+        const numTerm2 = SafeMath.div(D3, denomPart1);
+        const numerator = SafeMath.add(SafeMath.mul(A, B), numTerm2);
+
+        // Denominator: A * T + D^3 / (4 * A * B^2 * T)
+        const B2 = SafeMath.mul(B, B);
+        const denomPart2 = SafeMath.mul(SafeMath.mul(fourA, B2), T);
+        const denTerm2 = SafeMath.div(D3, denomPart2);
+        const denominator = SafeMath.add(SafeMath.mul(A, T), denTerm2);
+
+        if (denominator.isZero()) {
+            throw new Revert('StableSwap: denominator is zero');
+        }
+
+        // Scale for precision
+        return SafeMath.div(SafeMath.mul(numerator, QUOTE_SCALE), denominator);
+    }
+
+    // Compute new y given x and D for StableSwap
+    // Solves: A * 4 * (x + y) + D = A * D * 4 + D^3 / (4 * x * y)
+
+    // Solved iteratively using Newton's method
+    private computeStableD(x: u256, y: u256, A: u256): u256 {
+        const sum = SafeMath.add(x, y);
+
+        if (sum.isZero()) {
+            return u256.Zero;
+        }
+
+        const FOUR = u256.fromU32(4);
+        const TWO = u256.fromU32(2);
+        const Ann = SafeMath.mul(A, FOUR); // A * n^n where n=2
+
+        let D = sum;
+        let prevD: u256;
+
+        // Newton's method iterations
+        for (let i = 0; i < 255; i++) {
+            // D_P = D^3 / (4 * x * y)
+            const D2 = SafeMath.mul(D, D);
+            const D3 = SafeMath.mul(D2, D);
+            const xy4 = SafeMath.mul(SafeMath.mul(x, y), FOUR);
+
+            if (xy4.isZero()) {
+                throw new Revert('StableSwap: xy4 is zero');
+            }
+
+            const D_P = SafeMath.div(D3, xy4);
+
+            prevD = D;
+
+            // D = (Ann * sum + D_P * 2) * D / ((Ann - 1) * D + 3 * D_P)
+            const numerator = SafeMath.mul(
+                SafeMath.add(SafeMath.mul(Ann, sum), SafeMath.mul(D_P, TWO)),
+                D,
+            );
+
+            const denominator = SafeMath.add(
+                SafeMath.mul(SafeMath.sub(Ann, u256.One), D),
+                SafeMath.mul(u256.fromU32(3), D_P),
+            );
+
+            if (denominator.isZero()) {
+                throw new Revert('StableSwap: D denominator is zero');
+            }
+
+            D = SafeMath.div(numerator, denominator);
+
+            // Check convergence
+            const diff = D > prevD ? SafeMath.sub(D, prevD) : SafeMath.sub(prevD, D);
+            if (diff <= u256.One) {
+                return D;
+            }
+        }
+
+        throw new Revert('StableSwap: D did not converge');
+    }
+
+    // Rearranged to solve for y given x
+    private computeStableY(x: u256, D: u256, A: u256): u256 {
+        const FOUR = u256.fromU32(4);
+        const TWO = u256.fromU32(2);
+        const Ann = SafeMath.mul(A, FOUR);
+
+        // c = D^3 / (4 * Ann * x)
+        const D2 = SafeMath.mul(D, D);
+        const D3 = SafeMath.mul(D2, D);
+        const c = SafeMath.div(D3, SafeMath.mul(SafeMath.mul(Ann, x), FOUR));
+
+        // b = x + D / Ann
+        const b = SafeMath.add(x, SafeMath.div(D, Ann));
+
+        let y = D;
+        let prevY: u256;
+
+        // Newton's method: y = (y^2 + c) / (2 * y + b - D)
+        for (let i = 0; i < 255; i++) {
+            prevY = y;
+
+            const y2 = SafeMath.mul(y, y);
+            const numerator = SafeMath.add(y2, c);
+            const denominator = SafeMath.sub(SafeMath.add(SafeMath.mul(TWO, y), b), D);
+
+            if (denominator.isZero()) {
+                throw new Revert('StableSwap: Y denominator is zero');
+            }
+
+            y = SafeMath.div(numerator, denominator);
+
+            const diff = y > prevY ? SafeMath.sub(y, prevY) : SafeMath.sub(prevY, y);
+            if (diff <= u256.One) {
+                return y;
+            }
+        }
+
+        throw new Revert('StableSwap: Y did not converge');
+    }
+
+    private updateVirtualPoolStandard(T: u256, B: u256): void {
         const initialK = SafeMath.mul(B, T);
 
         // Add tokens from deltaTokensAdd (SELL SIDE)
@@ -534,6 +719,7 @@ export class LiquidityQueue implements ILiquidityQueue {
                 newK > initialK ? SafeMath.sub(newK, initialK) : SafeMath.sub(initialK, newK);
 
             const relativeTolerance = SafeMath.div(initialK, u256.fromU64(100000));
+
             if (diff > relativeTolerance) {
                 throw new Revert(
                     `Constant product broken after adding liquidity. Initial k: ${initialK}, New k: ${newK}`,
@@ -574,37 +760,62 @@ export class LiquidityQueue implements ILiquidityQueue {
 
         this.virtualSatoshisReserve = B.toU64();
         this.virtualTokenReserve = T;
-        this.resetAccumulators();
-
-        this.dynamicFee.volatility = this.computeVolatility(
-            currentBlock,
-            VOLATILITY_WINDOW_IN_BLOCKS,
-        );
-
-        this.lastVirtualUpdateBlock = currentBlock;
     }
 
-    protected computeVolatility(
-        currentBlock: u64,
-        windowSize: u32 = VOLATILITY_WINDOW_IN_BLOCKS,
-    ): u256 {
-        let volatility: u256 = u256.Zero;
+    private updateVirtualPoolStable(T: u256, B: u256): void {
+        const A = u256.fromU64(this.amplification);
 
-        const currentQuote: u256 = this.quoteManager.getBlockQuote(currentBlock);
-        const oldBlock: u64 = currentBlock - windowSize;
-        const oldQuote: u256 = this.quoteManager.getBlockQuote(oldBlock);
+        // Compute initial D
+        let D = this.computeStableD(T, B, A);
 
-        if (!oldQuote.isZero() && !currentQuote.isZero()) {
-            let diff = u256.sub(currentQuote, oldQuote);
-
-            if (diff.toI64() < 0) {
-                diff = u256.mul(diff, u256.fromI64(-1));
-            }
-
-            volatility = SafeMath.div(SafeMath.mul(diff, TEN_THOUSAND_U256), oldQuote);
+        // Apply sells: add tokens, recompute B to maintain D
+        const dT_add: u256 = this.totalTokensSellActivated;
+        if (!dT_add.isZero()) {
+            T = SafeMath.add(T, dT_add);
+            // Recompute D with new T, keeping the invariant property
+            // For StableSwap, D should increase when adding liquidity
+            D = this.computeStableD(T, B, A);
+            B = this.computeStableY(T, D, A);
         }
 
-        return volatility;
+        // Apply buys: remove tokens, add BTC
+        const dT_buy: u256 = this.totalTokensExchangedForSatoshis;
+        const dB_buy: u256 = u256.fromU64(this.totalSatoshisExchangedForTokens);
+
+        if (!dT_buy.isZero() || !dB_buy.isZero()) {
+            if (dT_buy >= T) {
+                throw new Revert(
+                    `Impossible state: Cannot buy ${dT_buy} tokens, only ${T} available`,
+                );
+            }
+
+            T = SafeMath.sub(T, dT_buy);
+            // Recompute B to maintain D
+            B = this.computeStableY(T, D, A);
+        }
+
+        if (T.isZero()) {
+            T = u256.One;
+        }
+
+        if (B > MAX_TOTAL_SATOSHIS) {
+            throw new Revert(
+                `Impossible state: New virtual satoshis reserve out of range. Value: ${B}`,
+            );
+        }
+
+        this.virtualSatoshisReserve = B.toU64();
+        this.virtualTokenReserve = T;
+    }
+
+    private applyStableSwapSell(T: u256, B: u256, dT: u256): StableSwapResult {
+        const A = u256.fromU64(this.amplification);
+        const newT = SafeMath.add(T, dT);
+        const D = this.computeStableD(T, B, A);
+        const newD = this.computeStableD(newT, B, A);
+        const newB = this.computeStableY(newT, newD, A);
+
+        return new StableSwapResult(newT, newB);
     }
 
     private calculateQueueImpact(): u256 {
@@ -636,14 +847,6 @@ export class LiquidityQueue implements ILiquidityQueue {
         }
 
         return reserve.toU64();
-    }
-
-    private ensurePenaltyNotLessThanHalf(penalty: u128, half: u128): void {
-        if (u128.lt(penalty, half)) {
-            throw new Revert(
-                `Penalty is less than half: ${penalty.toString()} < ${half.toString()}`,
-            );
-        }
     }
 
     private resetAccumulators(): void {

--- a/src/managers/LiquidityQueue.ts
+++ b/src/managers/LiquidityQueue.ts
@@ -722,6 +722,10 @@ export class LiquidityQueue implements ILiquidityQueue {
      * Newton's method: y = (y² + c) / (2y + b - D)
      */
     private computeStableY(x: u256, D: u256, A: u256): u256 {
+        if (x.isZero()) {
+            throw new Revert('StableSwap: Cannot compute Y with zero reserve');
+        }
+
         const FOUR = u256.fromU32(4);
         const TWO = u256.fromU32(2);
         const Ann = SafeMath.mul(A, FOUR);

--- a/src/managers/LiquidityQueue.ts
+++ b/src/managers/LiquidityQueue.ts
@@ -1,11 +1,4 @@
-import {
-    Address,
-    Blockchain,
-    Revert,
-    SafeMath,
-    StoredU256,
-    StoredU64,
-} from '@btc-vision/btc-runtime/runtime';
+import { Address, Blockchain, Revert, SafeMath, StoredU256, StoredU64, } from '@btc-vision/btc-runtime/runtime';
 import { u128, u256 } from '@btc-vision/as-bignum/assembly';
 
 import {
@@ -899,10 +892,9 @@ export class LiquidityQueue implements ILiquidityQueue {
 
     private applyStableSwapSell(T: u256, B: u256, dT: u256): StableSwapResult {
         const A = u256.fromU64(this.amplification);
+        const D = this.computeStableD(T, B, A); // original invariant
         const newT = SafeMath.add(T, dT);
-        const D = this.computeStableD(T, B, A);
-        const newD = this.computeStableD(newT, B, A);
-        const newB = this.computeStableY(newT, newD, A);
+        const newB = this.computeStableY(newT, D, A); // solve for B that maintains D
 
         return new StableSwapResult(newT, newB);
     }

--- a/src/managers/interfaces/ILiquidityQueue.ts
+++ b/src/managers/interfaces/ILiquidityQueue.ts
@@ -22,11 +22,11 @@ export interface ILiquidityQueue {
     virtualSatoshisReserve: u64;
     virtualTokenReserve: u256;
 
-    cleanUpQueues(currentQuote: u256): void;
-
     poolType: u8;
-
     amplification: u64;
+    pegStalenessThreshold: u64;
+
+    cleanUpQueues(currentQuote: u256): void;
 
     //accruePenalty(penalty: u128, half: u128): void;
 
@@ -91,6 +91,7 @@ export interface ILiquidityQueue {
         maxReserves5BlockPercent: u64,
         poolType: u8,
         amplification: u64,
+        pegStalenessThreshold: u64,
     ): void;
 
     purgeReservationsAndRestoreProviders(currentQuote: u256): void;

--- a/src/managers/interfaces/ILiquidityQueue.ts
+++ b/src/managers/interfaces/ILiquidityQueue.ts
@@ -24,6 +24,10 @@ export interface ILiquidityQueue {
 
     cleanUpQueues(currentQuote: u256): void;
 
+    poolType: u8;
+
+    amplification: u64;
+
     //accruePenalty(penalty: u128, half: u128): void;
 
     addReservation(reservation: Reservation): void;
@@ -85,6 +89,8 @@ export interface ILiquidityQueue {
         providerId: u256,
         initialLiquidity: u128,
         maxReserves5BlockPercent: u64,
+        poolType: u8,
+        amplification: u64,
     ): void;
 
     purgeReservationsAndRestoreProviders(currentQuote: u256): void;


### PR DESCRIPTION
Introduces stable pool type and amplification coefficient for improved pricing and slippage control in liquidity pools. Updates pool creation, management, and quoting logic to support both standard and stable pools, including new constants, storage pointers, and validation checks.

The stablecoin issuer is responsible for:

1. Deploying their OP-20 token with this interface
```ts
interface IOP20Stable {
    // Returns the target price in satoshis per token (scaled by 1e8)
    // For USD: if BTC = $100,000, then 1 USD = 1000 sats, returns 1000_00000000
    pegRate(): u256;
    
    // Returns the oracle/authority that can update the peg rate
    pegAuthority(): Address;
    
    // Returns timestamp of last peg update (for staleness checks)
    pegUpdatedAt(): u64;
}
```
3. Keeping pegRate() updated (via their own oracle, multisig, whatever)
4. Maintaining actual peg through their own collateral/mint/burn mechanisms

NativeSwap's job:

1. On createPool, check if token implements IOP20Stable
If yes, mark as stable pool

2. In quote() for stable pools, fetch pegRate() from the token contract
3. Use math centered around that peg rate
5. Optionally reject trades if pegUpdatedAt() is stale (configurable threshold)