### PR TITLE
Add contract upgrade and CSV reservation proof

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,8 @@
   "author": "MotoSwap",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/node": "^24.10.0",
-    "assemblyscript": "^0.28.9",
-    "prettier": "^3.6.2"
+    "@types/node": "^25.3.0",
+    "prettier": "^3.8.1"
   },
   "keywords": [
     "bitcoin",
@@ -30,17 +29,18 @@
   "type": "module",
   "dependencies": {
     "@assemblyscript/loader": "^0.28.9",
-    "@btc-vision/as-bignum": "^0.0.7",
+    "@btc-vision/as-bignum": "^0.1.2",
     "@btc-vision/as-covers-assembly": "^0.4.4",
     "@btc-vision/as-covers-transform": "^0.4.4",
     "@btc-vision/as-pect-assembly": "^8.2.0",
     "@btc-vision/as-pect-cli": "^8.2.0",
     "@btc-vision/as-pect-transform": "^8.2.0",
-    "@btc-vision/btc-runtime": "^1.10.12",
-    "@btc-vision/opnet-transform": "^0.1.12",
-    "@eslint/js": "9.39.1",
+    "@btc-vision/assemblyscript": "^0.29.2",
+    "@btc-vision/btc-runtime": "^1.11.0-rc.10",
+    "@btc-vision/opnet-transform": "^1.2.0",
+    "@eslint/js": "10.0.1",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.3",
-    "typescript-eslint": "^8.46.3"
+    "typescript-eslint": "^8.56.1"
   }
 }

--- a/src/constants/Contract.ts
+++ b/src/constants/Contract.ts
@@ -1,14 +1,14 @@
 import { u128, u256 } from '@btc-vision/as-bignum/assembly';
 
 export const INITIAL_FEE_COLLECT_ADDRESS: string =
-    'bcrt1qup339pnfsgz7rwu5qvw7e3pgdjmpda9zlwlg8ua70v3p8xl3tnqsjm472h';
+    'opt1qdn74lndmxp9f2m7tgfw8lmh939yeefym4qa7qatc3eaqs8jdlx9srz7kar';
 
 // tb1p823gdnqvk8a90f8cu30w8ywvk29uh8txtqqnsmk6f5ktd7hlyl0q3cyz4c
 // bcrt1plz0svv3wl05qrrv0dx8hvh5mgqc7jf3mhqgtw8jnj3l3d3cs6lzsfc3mxh
 
 export const ENABLE_FEES: bool = true;
 export const QUOTE_SCALE: u256 = u256.fromU64(100_000_000);
-export const RESERVATION_EXPIRE_AFTER_IN_BLOCKS: u64 = 8;
+export const RESERVATION_EXPIRE_AFTER_IN_BLOCKS: u64 = 5;
 export const VOLATILITY_WINDOW_IN_BLOCKS: u32 = 8;
 export const STRICT_MINIMUM_PROVIDER_RESERVATION_AMOUNT_IN_SAT: u64 = 600;
 export const MINIMUM_PROVIDER_RESERVATION_AMOUNT_IN_SAT: u64 = 1000;
@@ -16,7 +16,7 @@ export const MINIMUM_LIQUIDITY_VALUE_ADD_LIQUIDITY_IN_SAT: u64 = 10_000;
 export const MINIMUM_TRADE_SIZE_IN_SAT: u64 = 10_000;
 export const PERCENT_TOKENS_FOR_PRIORITY_QUEUE_TAX: u128 = u128.fromU32(30);
 export const PERCENT_TOKENS_FOR_PRIORITY_FACTOR_TAX: u128 = u128.fromU32(1000);
-export const TIMEOUT_AFTER_EXPIRATION_BLOCKS: u8 = 2;
+export const TIMEOUT_AFTER_EXPIRATION_BLOCKS: u8 = 0; //2;
 export const MAX_TOTAL_SATOSHIS: u256 = u256.fromU64(21_000_000 * 100_000_000);
 export const MAX_ACTIVATION_DELAY: u8 = 3;
 

--- a/src/contracts/NativeSwap.ts
+++ b/src/contracts/NativeSwap.ts
@@ -63,6 +63,7 @@ import { IDynamicFee } from '../managers/interfaces/IDynamicFee';
 import { DynamicFee } from '../managers/DynamicFee';
 import { WithdrawListingOperation } from '../operations/WithdrawListingOperation';
 import { SELECTOR_BYTE_LENGTH } from '@btc-vision/btc-runtime/runtime/utils/lengths';
+import { UpgradeContract } from '../events/UpgradeContract';
 
 class GetLiquidityQueueResult {
     public liquidityQueue: ILiquidityQueue;
@@ -115,7 +116,7 @@ export class NativeSwap extends ReentrancyGuard {
 
     public override execute(method: Selector, calldata: Calldata): BytesWriter {
         switch (method) {
-            case encodeSelector('reserve(address,uint64,uint256,uint8)'):
+            case encodeSelector('reserve(address,uint64,uint256,uint8,bytes)'):
                 return this.reserve(calldata);
             case encodeSelector('swap(address)'):
                 return this.swap(calldata);
@@ -171,9 +172,38 @@ export class NativeSwap extends ReentrancyGuard {
                 return this.getFeesAddress(calldata);
             case encodeSelector('onOP20Received(address,address,uint256,bytes)'):
                 return this.onOP20Received(calldata);
+            case encodeSelector('upgrade(address,bytes)'):
+                return this.upgrade(calldata);
             default:
                 return super.execute(method, calldata);
         }
+    }
+
+    public override onUpdate(calldata: Calldata): void {
+        super.onUpdate(calldata);
+    }
+
+    private upgrade(calldata: Calldata): BytesWriter {
+        if (Blockchain.tx.sender !== Blockchain.tx.origin) {
+            throw new Revert('NATIVE_SWAP: origin must be the sender.');
+        }
+
+        if (Blockchain.isContract(Blockchain.tx.sender)) {
+            throw new Revert('NATIVE_SWAP: sender must be EOA');
+        }
+
+        this.onlyDeployer(Blockchain.tx.sender);
+
+        const address: Address = calldata.readAddress();
+        const calldataUpgrade: Uint8Array = calldata.readBytesWithLength();
+
+        const writer = new BytesWriter(calldataUpgrade.length);
+        writer.writeBytes(calldataUpgrade);
+
+        Blockchain.updateContractFromExisting(address, writer);
+        Blockchain.emit(new UpgradeContract(address));
+
+        return new BytesWriter(0);
     }
 
     private getAntibotSettings(calldata: Calldata): BytesWriter {
@@ -496,9 +526,14 @@ export class NativeSwap extends ReentrancyGuard {
         const maximumAmountIn: u64 = calldata.readU64();
         const minimumAmountOut: u256 = calldata.readU256();
         const activationDelay: u8 = calldata.readU8();
+        const sender: Uint8Array = calldata.readBytesWithLength();
+        if (sender.length !== 33) {
+            throw new Revert('Invalid sender');
+        }
+
         this._tokenAddress = token.clone();
 
-        this._reserve(token, maximumAmountIn, minimumAmountOut, activationDelay);
+        this._reserve(token, maximumAmountIn, minimumAmountOut, activationDelay, sender);
 
         return new BytesWriter(0);
     }
@@ -508,6 +543,7 @@ export class NativeSwap extends ReentrancyGuard {
         maximumAmountIn: u64,
         minimumAmountOut: u256,
         activationDelay: u8,
+        sender: Uint8Array,
     ): void {
         this.ensureValidTokenAddress(token);
 
@@ -530,6 +566,7 @@ export class NativeSwap extends ReentrancyGuard {
             activationDelay,
             MAXIMUM_PROVIDER_PER_RESERVATIONS,
             MAXIMUM_NUMBER_OF_QUEUED_PROVIDER_TO_RESETS,
+            sender,
         );
 
         operation.execute();

--- a/src/events/UpgradeContract.ts
+++ b/src/events/UpgradeContract.ts
@@ -1,0 +1,16 @@
+import {
+    Address,
+    ADDRESS_BYTE_LENGTH,
+    BytesWriter,
+    NetEvent,
+} from '@btc-vision/btc-runtime/runtime';
+
+@final
+export class UpgradeContract extends NetEvent {
+    constructor(address: Address) {
+        const data: BytesWriter = new BytesWriter(ADDRESS_BYTE_LENGTH);
+        data.writeAddress(address);
+
+        super('Upgraded', data);
+    }
+}

--- a/src/managers/TradeManager.ts
+++ b/src/managers/TradeManager.ts
@@ -26,16 +26,19 @@ import { ProviderConsumedEvent } from '../events/ProviderConsumedEvent';
 
 export class TradeManager implements ITradeManager {
     protected readonly consumedOutputsFromUTXOs: Map<string, u64> = new Map<string, u64>();
+
     private readonly providerManager: IProviderManager;
     private readonly reservationManager: IReservationManager;
     private readonly quoteManager: IQuoteManager;
     private readonly liquidityQueueReserve: ILiquidityQueueReserve;
+
     private totalTokensPurchased: u256 = u256.Zero;
     private totalTokensRefunded: u256 = u256.Zero;
     private totalSatoshisSpent: u64 = 0;
     private totalSatoshisRefunded: u64 = 0;
     private tokensReserved: u256 = u256.Zero;
     private quoteToUse: u256 = u256.Zero;
+
     private readonly maximumResetsBeforeQueuing: u8;
 
     constructor(
@@ -85,7 +88,6 @@ export class TradeManager implements ITradeManager {
             }
 
             const satoshisSent: u64 = this.getSatoshisSent(provider.getBtcReceiver());
-
             if (satoshisSent !== 0) {
                 this.tryExecuteNormalOrPriorityTrade(
                     provider,

--- a/src/operations/ListTokensForSaleOperation.ts
+++ b/src/operations/ListTokensForSaleOperation.ts
@@ -4,6 +4,7 @@ import { addAmountToStakingContract, getProvider, Provider } from '../models/Pro
 import {
     BitcoinAddresses,
     Blockchain,
+    ExtendedAddress,
     Network,
     Revert,
     SafeMath,
@@ -199,8 +200,10 @@ export class ListTokensForSaleOperation extends BaseOperation {
         );
 
         if (!isValidCSV) {
+            const expected = ExtendedAddress.toCSV(this.receiver, CSV_BLOCKS_REQUIRED);
+
             throw new Revert(
-                `NATIVE_SWAP: Invalid receiver address. Expected CSV P2WSH address with ${CSV_BLOCKS_REQUIRED} blocks.`,
+                `NATIVE_SWAP: Invalid receiver address. Expected CSV P2WSH address with ${CSV_BLOCKS_REQUIRED} blocks. (not ${this.receiverStr}, expected ${expected})`,
             );
         }
     }

--- a/src/operations/ReserveLiquidityOperation.ts
+++ b/src/operations/ReserveLiquidityOperation.ts
@@ -1,5 +1,11 @@
 import { BaseOperation } from './BaseOperation';
-import { Address, Blockchain, Revert, SafeMath } from '@btc-vision/btc-runtime/runtime';
+import {
+    Address,
+    Blockchain,
+    ExtendedAddress,
+    Revert,
+    SafeMath,
+} from '@btc-vision/btc-runtime/runtime';
 import { Reservation } from '../models/Reservation';
 import { LiquidityReservedEvent } from '../events/LiquidityReservedEvent';
 import { ReservationCreatedEvent } from '../events/ReservationCreatedEvent';
@@ -28,17 +34,24 @@ import { Provider } from '../models/Provider';
 import { ReservationProviderData } from '../models/ReservationProdiverData';
 
 export class ReserveLiquidityOperation extends BaseOperation {
+    protected readonly consumedOutputsFromUTXOs: Map<string, u64> = new Map<string, u64>();
+
     protected currentQuote: u256 = u256.Zero;
     protected remainingTokens: u256 = u256.Zero;
     protected reservedProviderCount: u8 = 0;
+
     private readonly buyer: Address;
     private readonly maximumAmountInSats: u64;
     private readonly minimumAmountOutTokens: u256;
     private readonly providerId: u256;
 
+    private readonly sender: Uint8Array;
+
     private readonly activationDelay: u8;
+
     private reservedTokens: u256 = u256.Zero;
     private satoshisSpent: u64 = 0;
+
     private readonly maximumProvidersPerReservation: u8;
     private readonly numberOfFulfilledProviderToResets: u8;
 
@@ -51,6 +64,7 @@ export class ReserveLiquidityOperation extends BaseOperation {
         activationDelay: u8,
         maximumProvidersPerReservation: u8,
         numberOfFulfilledProviderToResets: u8,
+        sender: Uint8Array,
     ) {
         super(liquidityQueue);
 
@@ -61,21 +75,28 @@ export class ReserveLiquidityOperation extends BaseOperation {
         this.activationDelay = activationDelay;
         this.maximumProvidersPerReservation = maximumProvidersPerReservation;
         this.numberOfFulfilledProviderToResets = numberOfFulfilledProviderToResets;
+        this.sender = sender;
     }
 
     public override execute(): void {
         this.checkPreConditions();
         const reservation: Reservation = this.createReservation();
         this.getValidQuote();
+
         this.liquidityQueue.purgeReservationsAndRestoreProviders(this.currentQuote);
+
         this.ensureEnoughLiquidity();
         this.computeTokenRemaining();
+        this.verifySentEnoughSatoshi();
+
         this.reserve(reservation);
         this.ensureMinimumTokenReserved();
+
         this.liquidityQueue.increaseTotalReserved(this.reservedTokens);
         this.liquidityQueue.addReservation(reservation);
         this.liquidityQueue.setBlockQuote();
         this.liquidityQueue.cleanUpQueues(this.currentQuote);
+
         this.tryResetFulfilledProviders();
         this.emitReservationCreatedEvent();
     }
@@ -105,6 +126,29 @@ export class ReserveLiquidityOperation extends BaseOperation {
 
     protected limitByAvailableLiquidity(tokens: u256): u256 {
         return SafeMath.min(this.liquidityQueue.availableLiquidity, tokens);
+    }
+
+    protected getSatoshisSent(address: string): u64 {
+        let totalSatoshis: u64 = 0;
+        const outputs = Blockchain.tx.outputs;
+
+        for (let i = 0; i < outputs.length; i++) {
+            const output = outputs[i];
+
+            if (output.to === address) {
+                totalSatoshis = SafeMath.add64(totalSatoshis, output.value);
+            }
+        }
+
+        const consumedSatoshis: u64 = this.consumedOutputsFromUTXOs.has(address)
+            ? this.consumedOutputsFromUTXOs.get(address)
+            : 0;
+
+        if (totalSatoshis < consumedSatoshis) {
+            throw new Revert('Impossible state: Double spend detected.');
+        }
+
+        return totalSatoshis - consumedSatoshis;
     }
 
     private tryResetFulfilledProviders(): void {
@@ -444,6 +488,24 @@ export class ReserveLiquidityOperation extends BaseOperation {
 
     private limitByReservationCap(tokens: u256): u256 {
         return SafeMath.min(tokens, this.liquidityQueue.getMaximumTokensLeftBeforeCap());
+    }
+
+    private verifySentEnoughSatoshi(): void {
+        if (this.activationDelay === 0) {
+            throw new Revert(
+                'NATIVE_SWAP: Activation delay cannot be zero. Please set a positive activation delay to allow on-chain proof of ownership.',
+            );
+        }
+
+        const csvAddress = ExtendedAddress.toCSV(this.sender, this.activationDelay);
+        const sentSatoshis: u64 = this.getSatoshisSent(csvAddress);
+
+        const remainingSatoshis: u64 = tokensToSatoshis(this.remainingTokens, this.currentQuote);
+        if (remainingSatoshis > sentSatoshis) {
+            throw new Revert(
+                `NATIVE_SWAP: You must prove that you own at least ${remainingSatoshis} satoshis by sending them to yourself (${csvAddress}). Only ${sentSatoshis} sat were sent.`,
+            );
+        }
     }
 
     private reserve(reservation: Reservation): void {


### PR DESCRIPTION
Introduce on-chain contract upgrade support and require CSV-based sender proof for reservations. Changes include:

- Add UpgradeContract event and upgrade(...) in NativeSwap (EOA/origin checks, emits event, updateContract call).
- Extend reserve signature to accept sender bytes and propagate to ReserveLiquidityOperation.
- ReserveLiquidityOperation: store sender, track consumedOutputsFromUTXOs, implement getSatoshisSent, verifySentEnoughSatoshi (requires activationDelay > 0 and checks CSV address satoshi proof), and guard against double-spend accounting.
- Improve ListTokensForSaleOperation error message to show expected CSV address.
- Update constants (fee address, reservation expiration blocks reduced to 5, timeout after expiration set to 0) and minor config tweaks.
- Bump several dependencies and dev-deps in package.json.

These changes add an upgrade path for contracts and tighten reservation security by requiring proof of on-chain ownership via CSV outputs.